### PR TITLE
Webpack compatibility and addition of feature to delete models.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/
 *.pyc
 pastalog/dist
 pastalog/*.egg-info
+.ftpconfig
+*.log

--- a/pastalog/setup.py
+++ b/pastalog/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='pastalog',
-      version='1.0.2',
+      version='1.0.3',
       description='Simple, realtime visualization of neural network training performance.',
       url='http://github.com/rewonc/pastalog',
       author='Rewon Child',
@@ -11,6 +11,6 @@ setup(name='pastalog',
       install_requires=[
           'requests',
       ],
-      include_package_data = True,
+      include_package_data=True,
       scripts=['bin/pastalog'],
       zip_safe=False)

--- a/src/client.js
+++ b/src/client.js
@@ -17,6 +17,13 @@ const serverActions = {
     });
     console.log('deleting:', modelName, seriesName);
   },
+
+  deleteModel: (modelName) => {
+	  socket.emit('delete model', {
+		  modelName,
+    });
+    console.log('deleting:', modelName);
+  },
 };
 
 function render(state) {

--- a/src/components/Legend.js
+++ b/src/components/Legend.js
@@ -71,6 +71,21 @@ function Legend(props) {
         id: modelName,
       });
     };
+	  const deleteModel = (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const conf = window.confirm('Are you sure you want to ' +
+        'delete this model? It will no longer appear, and any new data ' +
+        'sent will create a new series.');
+      if (conf) {
+        props.actions.deleteModel(modelName);
+        // optimistically delete on client as well
+        props.store.dispatch({
+          modelName,
+          type: 'DELETEMODEL',
+        });
+      }
+    };
     return (
       <li key={modelName} onClick={toggle} className="sub">
         <span className={`${notEnabled ? 'deactivated' : 'activated'} h4 buttonLink`}>
@@ -79,6 +94,7 @@ function Legend(props) {
         <span className="bullet left">
           { notEnabled ? <span>&times;</span> : <span>&bull;</span> }
         </span>
+        <span className="h3 bold p0 m0 deleteButton buttonLink" onClick={deleteModel}>&#215;</span>
       </li>
     );
   });
@@ -110,10 +126,6 @@ function Legend(props) {
     <div className="legend-menu" style={
       { maxHeight: `${state.getIn(['size', 'height']) * 0.85}px` }}
     >
-    <h3 className="headlines h3">Series </h3>
-    <ul className="m1 list-reset">
-      {seriesElements}
-    </ul>
     <h3 className="headlines h3">Models </h3>
     <ul className="m1 list-reset">
       {modelElements}
@@ -121,6 +133,10 @@ function Legend(props) {
     <h3 className="headlines h3">Types </h3>
     <ul className="m1 list-reset">
       {typeElements}
+    </ul>
+    <h3 className="headlines h3">Series </h3>
+    <ul className="m1 list-reset">
+      {seriesElements}
     </ul>
     </div>
     <ScaleMenu {...props} />

--- a/src/server/routes.js
+++ b/src/server/routes.js
@@ -6,7 +6,7 @@ import Container from './../components/Container';
 import App from './../components/App';
 import { INITIAL_STATE } from './../state/actions';
 
-export default function makeRoutes({ app, store, io, db, addDataPoint, deleteSeries }) {
+export default function makeRoutes({ app, store, io, db, addDataPoint, deleteSeries, deleteModel }) {
   app.use(bodyParser.json());
   app.use(express.static('build/assets'));
 
@@ -34,6 +34,9 @@ export default function makeRoutes({ app, store, io, db, addDataPoint, deleteSer
     socket.emit('refreshed data', db.logs);
     socket.on('delete series', ({ modelName, seriesName }) => {
       deleteSeries(modelName, seriesName, socket);
+    });
+    socket.on('delete model', ({ modelName }) => {
+      deleteModel(modelName, socket);
     });
   });
 }

--- a/src/server/utils.js
+++ b/src/server/utils.js
@@ -17,7 +17,16 @@ export function PastaServer(app, store, io, db) {
     io.emit('refreshed data', logs);
   }
 
+  function deleteModel(modelName) {
+    const logs = db.logs;
+    // delete in current store and save DB
+    delete logs[modelName];
+    saveDB(db);
+    // emit new data
+    io.emit('refreshed data', logs);
+  }
+
   return {
-    app, store, io, db, addDataPoint, deleteSeries,
+    app, store, io, db, addDataPoint, deleteSeries, deleteModel,
   };
 }

--- a/src/state/reducer.js
+++ b/src/state/reducer.js
@@ -71,6 +71,8 @@ export default function reducer(state = INITIAL_STATE, action) {
           action.index, action.value);
     case 'DELETE':
       return state.deleteIn(['logs', action.modelName, action.seriesName]);
+    case 'DELETEMODEL':
+	    return state.deleteIn(['logs', action.modelName]);
     default:
       return state;
   }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -22,15 +22,15 @@ $green:     #859900;
 ::-webkit-scrollbar-track {
       background-color: $base02;
 } /* the new scrollbar will have a flat appearance with the set background color */
- 
+
 ::-webkit-scrollbar-thumb {
-      background-color: rgba(0, 0, 0, 0.2); 
+      background-color: rgba(0, 0, 0, 0.2);
 } /* this will style the thumb, ignoring the track */
- 
+
 ::-webkit-scrollbar-button {
       background-color: $base03;
 } /* optionally, you can style the top and the bottom buttons (left and right for horizontal bars) */
- 
+
 ::-webkit-scrollbar-corner {
       background-color: black;
 } /* if both the vertical and the horizontal bars appear, then perhaps the right bottom corner also needs to be styled */
@@ -128,7 +128,7 @@ body{
 }
 
 .gridMark {
-    @extend .h3;
+    @extend .h3 !optional;
     color: $base1;
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -84,7 +84,7 @@ module.exports = [
       extensions: ['.js', '.scss'],
     },
     node: {
-      console: 'mock',
+      console: false,
       fs: 'empty',
       net: 'empty',
       tls: 'empty',
@@ -111,7 +111,7 @@ module.exports = [
       ],
     },
     node: {
-      console: 'mock',
+      console: false,
       fs: 'empty',
       net: 'empty',
       tls: 'empty',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,7 @@ module.exports = [
         },
         {
           test: /\.scss$/,
-          loaders: ["style", "css", "sass"]
+          loaders: ["style-loader", "css-loader", "sass-loader"]
         },
       ],
     },
@@ -47,7 +47,7 @@ module.exports = [
       alias: {
         lib: __dirname + '/src/lib',
       },
-      extensions: ['', '.js', '.scss'],
+      extensions: ['.js', '.scss'],
     },
   },
 
@@ -73,7 +73,7 @@ module.exports = [
         },
         {
           test: /\.scss$/,
-          loaders: ["style", "css", "sass"]
+          loaders: ["style-loader", "css-loader", "sass-loader"]
         },
       ],
     },
@@ -81,10 +81,10 @@ module.exports = [
       alias: {
         lib: __dirname + '/src/lib',
       },
-      extensions: ['', '.js', '.scss'],
+      extensions: ['.js', '.scss'],
     },
     node: {
-      console: 'empty',
+      console: 'mock',
       fs: 'empty',
       net: 'empty',
       tls: 'empty',
@@ -111,7 +111,7 @@ module.exports = [
       ],
     },
     node: {
-      console: 'empty',
+      console: 'mock',
       fs: 'empty',
       net: 'empty',
       tls: 'empty',


### PR DESCRIPTION
- Modified webpack file so that it is compatible with webpack 2.7+ (latest version)
- Modified legend so that we see Models first, then types and then series (Reason being this seems much more intuitive than earlier one, one can easily switch models they want to see and select what types, rather than individually selecting series names.)
- Added feature so that you can delete the complete model data. 

*TODO* - Backup the data when model is deleted. 